### PR TITLE
Fixed filter modal not showing up

### DIFF
--- a/public/scripts/global-scripts/modals.mjs
+++ b/public/scripts/global-scripts/modals.mjs
@@ -47,5 +47,5 @@ export function initialiseModal(modal) {
  */
 export default function initModals() {
   // Add click event listeners to all modal toggle buttons
-  document.querySelectorAll('.modal').forEach(initialiseModal);
+  document.querySelectorAll('[data-modal]').forEach(initialiseModal);
 }

--- a/src/partials/modal.ejs
+++ b/src/partials/modal.ejs
@@ -1,4 +1,4 @@
-<div class="modal invisible" id="<%= modalID %>" tabindex="-1" role="dialog">
+<div class="modal invisible" id="<%= modalID %>" tabindex="-1" role="dialog" data-modal>
   <div
     class="modal-overlay"
     data-close="modal"

--- a/src/partials/plant-filters.ejs
+++ b/src/partials/plant-filters.ejs
@@ -11,7 +11,7 @@
 </button>
 
 <div id="filters" class="max-lg:modal invisible lg:visible" data-modal>
-  <div class="modal-overlay lg:hidden" data-close="modal"></div>
+  <div class="modal-overlay lg:hidden" data-close="modal" data-target="filters"></div>
   <div class="max-lg:modal-container">
     <div class="mb-4 flex items-center justify-between lg:hidden">
       <h5 class="modal-title text-xl font-semibold">Filter Plants</h5>
@@ -20,6 +20,7 @@
         aria-label="Close modal"
         title="Close modal"
         data-close="modal"
+        data-target="filters"
       >
         <span class="material-symbols-outlined">close</span>
       </button>


### PR DESCRIPTION
Modals are now found by the initialiser function by a `data-modal` attribute, preventing tailwind selector classes from breaking them.